### PR TITLE
Add caller

### DIFF
--- a/counsel-world-clock.el
+++ b/counsel-world-clock.el
@@ -539,6 +539,7 @@ added which is replaced by the return value of
     (ivy-read
      "Time zone: "
      counsel-world-clock--time-zones
+     :caller 'counsel-world-clock
      :action (lambda (time-zone)
 	       (message
 		"Local time in %s is %s"


### PR DESCRIPTION
To handle `counsel-world-clock` in `prescient.el`[1], just added `caller`.

[1] https://github.com/raxod502/prescient.el